### PR TITLE
Adding age matcher (older/younger)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,18 @@ Windows machine yet.
 usage: fu [<flags>] <query> [<paths>...]
 
 Flags:
-  -h, --help       Show context-sensitive help (also try --help-long and
-                   --help-man).
-  -f, --fuzzy      Use fuzzy search
-  -r, --regexp     Use regexp-based search
-  -a, --suffix     Use suffix-based search (short flag 'a' is short for for
-                   'after')
-  -b, --prefix     Use prefix-based search (short flag 'b' is short for
-                   'before')
-  -s, --substring  Use substring-based search allowing the query to be at any
-                   position in the filename
-  -d, --dir        Show only directories
-  -m, --perm=PERM  Filter by Unix permissions
-  -c, --parallel   Walk directories in parallel, may result in substantial
-                   speedups for directories with many files
-  -v, --version    Show application version.
+  -h, --help             Show context-sensitive help (also try --help-long and --help-man).
+  -f, --fuzzy            Use fuzzy search
+  -r, --regexp           Use regexp-based search
+  -a, --suffix           Use suffix-based search (short flag 'a' is short for 'after')
+  -b, --prefix           Use prefix-based search (short flag 'b' is short for 'before')
+  -s, --substring        Use substring-based search allowing the query to be at any position in the filename
+  -d, --dir              Show only directories
+  -m, --perm=PERM        Filter by Unix permissions
+  -c, --parallel         Walk directories in parallel, may result in substantial speedups for directories with many files
+  -o, --older=OLDER      Filter by age (modification time)
+  -y, --younger=YOUNGER  Filter by age (modification time)
+  -v, --version          Show application version.
 
 Args:
   <query>    Search query

--- a/fu.go
+++ b/fu.go
@@ -34,6 +34,8 @@ func main() {
 		"Walk directories in parallel, may result in substantial speedups "+
 			"for directories with many files").
 		Short('c').Bool()
+	older := kingpin.Flag("older", "Filter by age (modification time)").Short('o').Duration()
+	younger := kingpin.Flag("younger", "Filter by age (modification time)").Short('y').Duration()
 
 	query := kingpin.Arg("query", "Search query").Required().String()
 	paths := kingpin.Arg("paths", "Paths to search").Default(".").ExistingDirs()
@@ -84,6 +86,12 @@ func main() {
 	}
 	if *dir {
 		ms = append(ms, matchers.NewDirMatcher())
+	}
+	if *older != 0 {
+		ms = append(ms, matchers.NewAgeOlderMatcher(*older))
+	}
+	if *younger != 0 {
+		ms = append(ms, matchers.NewAgeYoungerMatcher(*younger))
 	}
 
 	rdx := shallowradix.New()

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kbrgl/fuzzy"
+	"time"
 )
 
 // FileMatcher is an interface providing a Match method that checks whether a
@@ -124,6 +125,34 @@ func NewDirMatcher() *DirMatcher {
 // Match returns true for dirs.
 func (d DirMatcher) Match(fi os.FileInfo) bool {
 	return fi.IsDir()
+}
+
+type AgeOlderMatcher struct {
+	age time.Duration
+}
+
+func NewAgeOlderMatcher(age time.Duration) *AgeOlderMatcher {
+	return &AgeOlderMatcher{
+		age: age,
+	}
+}
+
+func (o AgeOlderMatcher) Match(fi os.FileInfo) bool {
+	return fi.ModTime().Before(time.Now().Add(-1 * o.age))
+}
+
+type AgeYoungerMatcher struct {
+	age time.Duration
+}
+
+func NewAgeYoungerMatcher(age time.Duration) *AgeYoungerMatcher {
+	return &AgeYoungerMatcher{
+		age: age,
+	}
+}
+
+func (y AgeYoungerMatcher) Match(fi os.FileInfo) bool {
+	return fi.ModTime().After(time.Now().Add(-1 * y.age))
 }
 
 // AllMatcher allows everything.


### PR DESCRIPTION
This allows for an easy filtering on age, without cluttering the cli.

Examples:

```
fu -a .go -o 1h # returns .go files modified more than 1h ago
fu -a .go -y 30m # returns .go files modified less than 1h ago
```

New flags:

- `-o --older=AGE`
- `-y --younger=AGE`