### PR TITLE
Adding exclude flag to reverse the matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Flags:
   -c, --parallel         Walk directories in parallel, may result in substantial speedups for directories with many files
   -o, --older=OLDER      Filter by age (modification time)
   -y, --younger=YOUNGER  Filter by age (modification time)
-  -e, --exclude          Exludes files matching the filters
+  -e, --exclude          Excludes files matching the filters
   -v, --version          Show application version.
 
 Args:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Flags:
   -c, --parallel         Walk directories in parallel, may result in substantial speedups for directories with many files
   -o, --older=OLDER      Filter by age (modification time)
   -y, --younger=YOUNGER  Filter by age (modification time)
+  -e, --exclude          Exludes files matching the filters
   -v, --version          Show application version.
 
 Args:

--- a/fu.go
+++ b/fu.go
@@ -36,6 +36,7 @@ func main() {
 		Short('c').Bool()
 	older := kingpin.Flag("older", "Filter by age (modification time)").Short('o').Duration()
 	younger := kingpin.Flag("younger", "Filter by age (modification time)").Short('y').Duration()
+	exclude := kingpin.Flag("exclude", "Exludes files matching the filters").Short('e').Bool()
 
 	query := kingpin.Arg("query", "Search query").Required().String()
 	paths := kingpin.Arg("paths", "Paths to search").Default(".").ExistingDirs()
@@ -118,7 +119,7 @@ func main() {
 
 			matches := true
 			for _, matcher := range ms {
-				if !matcher.Match(fi) {
+				if matcher.Match(fi) == *exclude {
 					matches = false
 				}
 			}

--- a/fu.go
+++ b/fu.go
@@ -36,7 +36,7 @@ func main() {
 		Short('c').Bool()
 	older := kingpin.Flag("older", "Filter by age (modification time)").Short('o').Duration()
 	younger := kingpin.Flag("younger", "Filter by age (modification time)").Short('y').Duration()
-	exclude := kingpin.Flag("exclude", "Exludes files matching the filters").Short('e').Bool()
+	exclude := kingpin.Flag("exclude", "Excludes files matching the filters").Short('e').Bool()
 
 	query := kingpin.Arg("query", "Search query").Required().String()
 	paths := kingpin.Arg("paths", "Paths to search").Default(".").ExistingDirs()


### PR DESCRIPTION
This flag reverses the matching (name and otherwise). Semantically it
translates to list all files excluding those matching ...

Flag Added:

- `-e --exclude`

Examples:

```
fu -e -a .go # lists all non-go files and directories
fu -e -d -a .go # lists all non-go files (excluding directories)
fu -e '' # list all files
fu -e -d '' # list all files (and only files)
```